### PR TITLE
fix: correct swapped auto_upgrade/auto_repair in NAP defaults (INFRA-900)

### DIFF
--- a/.github/workflows/terraform-test.yaml
+++ b/.github/workflows/terraform-test.yaml
@@ -1,0 +1,8 @@
+name: OpenTofu Test
+on:
+  - pull_request
+
+jobs:
+  tofu-test:
+    name: OpenTofu Test
+    uses: truefoundry/github-workflows-public/.github/workflows/terraform-test.yml@main

--- a/gke.tf
+++ b/gke.tf
@@ -115,8 +115,8 @@ resource "google_container_cluster" "cluster" {
         enable_integrity_monitoring = var.cluster_nap_node_config.enable_integrity_monitoring
       }
       management {
-        auto_upgrade = var.cluster_nap_node_config.auto_repair
-        auto_repair  = var.cluster_nap_node_config.auto_upgrade
+        auto_upgrade = var.cluster_nap_node_config.auto_upgrade
+        auto_repair  = var.cluster_nap_node_config.auto_repair
       }
       upgrade_settings {
         strategy        = "SURGE"

--- a/tests/nap_management.tftest.hcl
+++ b/tests/nap_management.tftest.hcl
@@ -1,0 +1,58 @@
+# Regression tests for INFRA-900: ensure the NAP auto_provisioning_defaults
+# management block wires auto_upgrade/auto_repair to their matching variables
+# (they were previously swapped).
+#
+# Uses mock providers + plan-only runs so no GCP credentials are required.
+
+mock_provider "google" {}
+mock_provider "google-beta" {}
+
+# Required inputs shared by every run. Values are placeholders — the cluster is
+# never actually provisioned (command = plan).
+variables {
+  cluster_name                   = "tfy-test"
+  region                         = "us-central1"
+  project                        = "tfy-test-project"
+  cluster_node_locations         = ["us-central1-a"]
+  cluster_network_id             = "projects/tfy-test-project/global/networks/tfy-test"
+  cluster_subnet_id              = "projects/tfy-test-project/regions/us-central1/subnetworks/tfy-test"
+  cluster_master_ipv4_cidr_block = "172.16.0.0/28"
+}
+
+# Key regression: distinct values for auto_repair and auto_upgrade so a swap is
+# detectable. Fails on the pre-fix code where the two were crossed.
+run "nap_management_distinct_values" {
+  command = plan
+
+  variables {
+    cluster_nap_node_config = {
+      auto_repair  = false
+      auto_upgrade = true
+    }
+  }
+
+  assert {
+    condition     = google_container_cluster.cluster[0].cluster_autoscaling[0].auto_provisioning_defaults[0].management[0].auto_upgrade == true
+    error_message = "NAP auto_provisioning_defaults.management.auto_upgrade must match var.cluster_nap_node_config.auto_upgrade (expected true)"
+  }
+
+  assert {
+    condition     = google_container_cluster.cluster[0].cluster_autoscaling[0].auto_provisioning_defaults[0].management[0].auto_repair == false
+    error_message = "NAP auto_provisioning_defaults.management.auto_repair must match var.cluster_nap_node_config.auto_repair (expected false)"
+  }
+}
+
+# Sanity check: defaults leave both flags enabled.
+run "nap_management_defaults" {
+  command = plan
+
+  assert {
+    condition     = google_container_cluster.cluster[0].cluster_autoscaling[0].auto_provisioning_defaults[0].management[0].auto_upgrade == true
+    error_message = "NAP auto_provisioning_defaults.management.auto_upgrade should default to true"
+  }
+
+  assert {
+    condition     = google_container_cluster.cluster[0].cluster_autoscaling[0].auto_provisioning_defaults[0].management[0].auto_repair == true
+    error_message = "NAP auto_provisioning_defaults.management.auto_repair should default to true"
+  }
+}


### PR DESCRIPTION
## Summary

The NAP `cluster_autoscaling.auto_provisioning_defaults.management` block in `gke.tf` wired its two fields to the **wrong** variables — `auto_upgrade` was assigned from `var.cluster_nap_node_config.auto_repair` and `auto_repair` from `.auto_upgrade`.

- Harmless while both vars are left at their `true` defaults (both resolve to the same value).
- Becomes a real bug once either is set to a non-default value: the setting lands on the opposite field.
- Elevated risk on the `STABLE` release channel — a user setting `auto_repair = false` would unintentionally disable **auto_upgrade** on NAP pools, which per GKE docs can cause GKE to fail creating new node pools.

## Changes

- **`gke.tf`** — swap the two assignments so each `management` field maps to its matching variable.
- **`tests/nap_management.tftest.hcl`** — new OpenTofu native tests (mock provider, `command = plan`, no GCP creds). Asserts the rendered management block matches the inputs:
  - `nap_management_distinct_values` — `auto_repair=false, auto_upgrade=true`, the regression guard.
  - `nap_management_defaults` — both default to `true`.
- **`.github/workflows/terraform-test.yaml`** — runs the tests in CI via the reusable `terraform-test.yml` workflow from `github-workflows-public` (pinned to `@main`; not yet tagged).

## Verification

- `tofu test` → **2 passed, 0 failed** with the fix.
- Regression check: reverting the swap makes `nap_management_distinct_values` **fail** with the exact expected mismatch — confirming the test guards the bug. Fix then restored, tests green.
- `tofu fmt -check -recursive` → clean.

## History

Introduced already-swapped in `cc6ff45` ("Updated parameters for GKE", Sep 12 2023); masked ever since because both vars default to `true`.

Closes INFRA-900
https://linear.app/truefoundry/issue/INFRA-900/nap-auto-provisioning-defaults-swaps-auto-upgrade-and-auto-repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GKE cluster management flags for NAP node pools; wrong wiring could affect upgrades/repair in production when non-default values are set, though the fix aligns behavior with intended config.
> 
> **Overview**
> Fixes **INFRA-900** by wiring NAP `auto_provisioning_defaults.management` so **`auto_upgrade`** and **`auto_repair`** each use the matching `var.cluster_nap_node_config` field (they were previously crossed). That bug was hidden while both vars default to `true`, but divergent settings would apply the wrong GKE behavior—e.g. disabling repair could unintentionally turn off upgrades on NAP pools.
> 
> Adds **OpenTofu plan-only tests** in `tests/nap_management.tftest.hcl` (mock Google providers, no GCP creds): one run with distinct `auto_repair`/`auto_upgrade` values as a regression guard, plus a defaults sanity check.
> 
> Adds a **PR CI workflow** (`.github/workflows/terraform-test.yaml`) that delegates to the shared `terraform-test.yml` reusable workflow so `tofu test` runs on pull requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3ca963e2e6024836497d99384af7a263b64833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->